### PR TITLE
Message rework

### DIFF
--- a/pyloxone_api/__main__.py
+++ b/pyloxone_api/__main__.py
@@ -17,6 +17,12 @@ from . import LoxAPI
 _LOGGER = logging.getLogger("pyloxone_api")
 _LOGGER.setLevel(logging.DEBUG)
 _LOGGER.addHandler(logging.StreamHandler())
+# If you want to see what is going on at the websocket level, uncomment the following
+# lines
+
+# _LOGGER2 = logging.getLogger("websockets")
+# _LOGGER2.setLevel(logging.DEBUG)
+# _LOGGER2.addHandler(logging.StreamHandler())
 
 
 async def main():

--- a/pyloxone_api/api.py
+++ b/pyloxone_api/api.py
@@ -441,7 +441,8 @@ class LoxAPI:
         except asyncio.CancelledError:
             _LOGGER.debug("Cancelling .....")
             raise
-        except:
+        except Exception as exc:
+            _LOGGER.exception(exc)
             await asyncio.sleep(5)
             if self._ws.closed and self._ws.close_code in [4004, 4005]:
                 self._token.delete()

--- a/pyloxone_api/const.py
+++ b/pyloxone_api/const.py
@@ -21,8 +21,8 @@ TOKEN_PERMISSION = 4  # 2=web, 4=app
 TOKEN_REFRESH_RETRY_COUNT = 5
 # token will be refreshed 1 day before its expiration date
 TOKEN_REFRESH_SECONDS_BEFORE_EXPIRY = 24 * 60 * 60  # 1 day
-#  if can't determine token expiration date, it will be refreshed after 2 days
-TOKEN_REFRESH_DEFAULT_SECONDS = 2 * 24 * 60 * 60  # 2 days
+
+
 
 LOXAPPPATH = "/data/LoxAPP3.json"
 

--- a/pyloxone_api/message.py
+++ b/pyloxone_api/message.py
@@ -1,0 +1,193 @@
+"""Classes for handling messages from a miniserver"""
+from __future__ import annotations
+
+import math
+import struct
+import uuid
+from enum import IntEnum
+from typing import Any
+
+from pyloxone_api.exceptions import LoxoneException
+
+
+class MessageType(IntEnum):
+    """The different types of message which the miniserver might send"""
+
+    TEXT = 0
+    BINARY = 1
+    VALUE_STATES = 2
+    TEXT_STATES = 3
+    DAYTIMER_STATES = 4
+    OUT_OF_SERVICE = 5
+    KEEPALIVE = 6
+    WEATHER_STATES = 7
+
+
+class MessageHeader:
+    def __init__(self, header: bytes) -> None:
+        # From the Loxone API docs, the header is as follows
+        # typedef struct {
+        #   BYTE cBinType;     // fix 0x03
+        #   BYTE cIdentifier;  // 8-Bit Unsigned Integer (little endian)
+        #   BYTE cInfo;        // Info
+        #   BYTE cReserved;    // reserved
+        #   UINT nLen;         // 32-Bit Unsigned Integer (little endian)
+        # } PACKED WsBinHdr;
+        self.header = header
+        if not header[0] == 3:
+            raise LoxoneException(r"Invalid header received: first byte is not \0x03")
+        try:
+            unpacked_data = struct.unpack("<cBccI", header)
+        except (struct.error, TypeError) as exc:
+            raise LoxoneException(f"Invalid header received: {exc}")
+        self.message_type: MessageType = MessageType(unpacked_data[1])
+        # First bit indicates that length is only estimated
+        self.estimated: bool = ord(unpacked_data[2]) >> 7 == 1
+        self.payload_length: int = int(unpacked_data[4])
+
+
+class BaseMessage:
+    """The base class for all messages from the miniserver"""
+
+    def __init__(self, message: bytes) -> None:
+        self.message: bytes = message
+        # For the base class, the dict is the message
+        self._dict = message
+
+    def as_dict(self) -> Any:
+        """Return the contents of the message as a dict"""
+        return self._dict
+
+
+class TextMessage(BaseMessage):
+    message_type = MessageType.TEXT
+    # Nothing to do. as_dict inherits from the base class: the dict is the message
+    pass
+
+
+class BinaryFile(BaseMessage):
+    message_type = MessageType.BINARY
+
+    # The message is a binary file. There is nothing parse
+    def as_dict(self):
+        return {}
+
+
+class ValueStatesTable(BaseMessage):
+    message_type = MessageType.VALUE_STATES
+
+    # A value state is as follows:
+    # typedef struct {
+    #     PUUID uuid;   // 128-Bit uuid
+    #     double dVal;  // 64-Bit Float (little endian) value
+    # } PACKED EvData;
+
+    def as_dict(self):
+        event_dict = {}
+        length = len(self.message)
+        num = length / 24
+        start = 0
+        end = 24
+        for _ in range(int(num)):
+            packet = self.message[start:end]
+            event_uuid = uuid.UUID(bytes_le=packet[0:16])
+            fields = event_uuid.urn.replace("urn:uuid:", "").split("-")
+            uuidstr = f"{fields[0]}-{fields[1]}-{fields[2]}-{fields[3]}{fields[4]}"
+            value = struct.unpack("d", packet[16:24])[0]
+            event_dict[uuidstr] = value
+            start += 24
+            end += 24
+        return event_dict
+
+
+class TextStatesTable(BaseMessage):
+    message_type = MessageType.TEXT_STATES
+
+    # A text event state is as follows:
+    # typedef struct {                 // starts at multiple of 4
+    #     PUUID uuid;                  // 128-Bit uuid
+    #     PUUID uuidIcon;              // 128-Bit uuid of icon
+    #     unsigned long textLength;    // 32-Bit Unsigned Integer (little endian)
+    #     // text follows here
+    #     } PACKED EvDataText;
+    def as_dict(self):
+        event_dict = {}
+        start = 0
+
+        def get_text(message, start, offset):
+            first = start
+            second = start + offset
+            event_uuid = uuid.UUID(bytes_le=self.message[first:second])
+            first += offset
+            second += offset
+
+            icon_uuid_fields = event_uuid.urn.replace("urn:uuid:", "").split("-")
+            uuidstr = "{}-{}-{}-{}{}".format(
+                icon_uuid_fields[0],
+                icon_uuid_fields[1],
+                icon_uuid_fields[2],
+                icon_uuid_fields[3],
+                icon_uuid_fields[4],
+            )
+
+            icon_uuid = uuid.UUID(bytes_le=self.message[first:second])
+            icon_uuid_fields = icon_uuid.urn.replace("urn:uuid:", "").split("-")
+
+            first = second
+            second += 4
+
+            text_length = struct.unpack("<I", message[first:second])[0]
+
+            first = second
+            second = first + text_length
+            message_str = struct.unpack(f"{text_length}s", message[first:second])[0]
+            start += (math.floor((4 + text_length + 16 + 16 - 1) / 4) + 1) * 4
+            event_dict[uuidstr] = message_str.decode("utf-8")
+            return start
+
+        while start < len(self.message):
+            start = get_text(self.message, start, 16)
+        return event_dict
+
+
+class DaytimerStatesTable(BaseMessage):
+    message_type = MessageType.DAYTIMER_STATES
+
+    # We dont currently handle this.
+    def as_dict(self):
+        return {}
+
+
+class OutOfServiceIndicator(BaseMessage):
+    message_type = MessageType.OUT_OF_SERVICE
+
+    # There can be no such message. If an out-of-service header is sent, the
+    # miniserver will close the connection before sending a message.
+    pass
+
+
+class Keepalive(BaseMessage):
+    message_type = MessageType.KEEPALIVE
+
+    # Nothing to do. The dict is the message (which is b'keepalive')
+    def as_dict(self):
+        return {"keep_alive": "received"}
+
+
+class WeatherStatesTable(BaseMessage):
+    message_type = MessageType.WEATHER_STATES
+
+    def as_dict(self):
+        return {}
+
+
+def parse_header(header: bytes) -> MessageHeader:
+    return MessageHeader(header)
+
+
+def parse_message(message: bytes, message_type: int) -> BaseMessage:
+    """Return an instance of the appropriate BaseMessage subclass"""
+    for klass in BaseMessage.__subclasses__():
+        if klass.message_type == message_type:
+            return klass(message)
+    raise LoxoneException(f"Unknown message type {message_type}")

--- a/pyloxone_api/websocket.py
+++ b/pyloxone_api/websocket.py
@@ -1,0 +1,47 @@
+"""A websocket implementation with useful methods"""
+import asyncio
+from pyloxone_api.message import MessageType, parse_header, parse_message
+from websockets.client import WebSocketClientProtocol
+
+
+class Websocket(WebSocketClientProtocol):
+    socket_lock = asyncio.Lock()
+
+    async def recv(self):
+        async with self.socket_lock:
+            result = await super().recv()
+        return result
+
+    async def recv_message(self):
+        """Receive a header and message from the miniserver""
+
+        Return an instance of the appropriate message.BaseMessage subclass
+        """
+        # The Loxone API docs say:
+        #
+        # > As mentioned in the chapter on how to setup a connection, messages sent by
+        # > the Miniserver are always prequeled by a binary message that contains a
+        # > MessageHeader. So at ﬁrst you’ll receive the binary Message-Header and then
+        # > the payload follows in a separate message.
+        #
+        # But this is not quite right. The docs also say, for an out-of-service
+        # indicator:
+        #
+        # > No message is going to follow this header, the Miniserver closes the
+        # > connection afterwards, the client may try to reconnect.
+        #
+        # And:
+        #
+        # > An Estimated-Header is always followed by an exact Header to be able to read
+        # > the data correctly!
+
+        async with self.socket_lock:
+            header_data = await super().recv()
+            header = parse_header(header_data)
+            if header.message_type is MessageType.OUT_OF_SERVICE:
+                return None
+            # get the message body
+            message_data = await super().recv()
+
+        message = parse_message(message_data, header.message_type)
+        return message.message

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,20 @@
+from pyloxone_api.exceptions import LoxoneException
+from pyloxone_api.message import parse_header, MessageType
+import pytest
+
+HEADER1 = b"\x03\x01\xFF\x00\x9c\x17\x00\x00"
+BADMESSAGE1 = b"\x03\x01\x00\x00\x9c\x17\x00\x00\x03"
+BADMESSAGE2 = b"\x02\x01\x00\x00\x9c\x17\x00\x00"
+
+
+def test_header():
+    l = parse_header(HEADER1)
+    assert l.message_type == MessageType.BINARY
+    assert l.estimated is True
+    assert l.payload_length == 6044
+
+
+@pytest.mark.parametrize("message", [BADMESSAGE1, BADMESSAGE2])
+def test_bad_header(message):
+    with pytest.raises(LoxoneException):
+        parse_header(message)


### PR DESCRIPTION
For discussion:

This is a fairly extensive rework of message parsing. Messages are now parsed by specific classes. I have also subclassed the websocket to enable more detailed logging, and to centralise message handling a bit more.

I found a couple of race-conditions in the original code. If a keep alive message or token refresh request was sent to the mini server at the same time as an incoming message was being processed then the incoming message could become garbled. I have fixed these, I hope, but there is still scope for this to happen. You can see this if you set the refresh and keep alive times to, eg, 10 seconds, and cause the mini server to send a number of messages quickly (eg changing a slider up and down). This is not likely to happen often, but it is a possibility. 